### PR TITLE
Bugfix for #150 wrong content lenght calculation

### DIFF
--- a/inc/modelcsv.class.php
+++ b/inc/modelcsv.class.php
@@ -92,7 +92,7 @@ class PluginDatainjectionModelcsv extends CommonDBChild
       );
       header('Content-Type: text/comma-separated-values');
       header('Content-Transfer-Encoding: UTF-8');
-      header('Content-Length: '.mb_strlen($sample, 'UTF-8'));
+      header('Content-Length: '.strlen($sample));
       header('Pragma: no-cache');
       header('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
       header('Expires: 0');


### PR DESCRIPTION
Replace mb_strlen that computes characters with strlen that computes bytes, because HTTP header content-lenght expects a byte count, not a character count.